### PR TITLE
[CredProvider.NET.Tester] Change Release-build platform to x64

### DIFF
--- a/CredProvider.NET.Tester/CredProvider.NET.Tester.csproj
+++ b/CredProvider.NET.Tester/CredProvider.NET.Tester.csproj
@@ -23,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>


### PR DESCRIPTION
Done to become consistent with the CredProvider.NET project that's already using `x64` as `PlatformTarget` in both debug & release. It also fixes the following warning on release builds:
`warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "C:\Dev\CredProvider.NET\CredProvider.NET\bin\Release\CredProvider.NET.dll", "AMD64".`