### PR TITLE
Simplify log folder path logic

### DIFF
--- a/CredProvider.NET/Logger.cs
+++ b/CredProvider.NET/Logger.cs
@@ -60,7 +60,7 @@ namespace CredProvider.NET
         {
             if (path == null)
             {
-                var folder = $"{Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.System)).FullName}\\Logs\\CredProviderNET";
+                var folder = $"{Environment.GetFolderPath(Environment.SpecialFolder.Windows)}\\Logs\\CredProviderNET";
 
                 if (!Directory.Exists(folder)) Directory.CreateDirectory(folder);
 


### PR DESCRIPTION
Replace convoluted code that determines the parent folder of `C:\WINDOWS\system32` with more direct `C:\WINDOWS` folder lookup. The resulting log folder is still `C:\WINDOWS\Logs\CredProviderNET`, so there's no change in behavior.